### PR TITLE
Revert "Temp revert to kubernetes 1.10 for testing"

### DIFF
--- a/images/acs_engine_prow_test/build.sh
+++ b/images/acs_engine_prow_test/build.sh
@@ -149,9 +149,9 @@ set +e
 ${KUBETEST} --deployment=acsengine --provider=azure --test=true --up=true --down=true --ginkgo-parallel=${GINKGO_PARALLEL} \
             --acsengine-resource-name=${AZ_DEPLOYMENT_NAME} --acsengine-agentpoolcount=${AGENT_NODES} \
             --acsengine-resourcegroup-name=${AZ_RG_NAME} --acsengine-admin-password=Passw0rdAdmin \
-            --acsengine-admin-username=azureuser --acsengine-orchestratorRelease=1.10 \
-            --acsengine-hyperkube-url=k8s-gcrio.azureedge.net/hyperkube-amd64:v1.10.5 \
-            --acsengine-win-binaries-url=https://acs-mirror.azureedge.net/wink8s/v1.10.5-1int.zip \
+            --acsengine-admin-username=azureuser --acsengine-orchestratorRelease=1.11 \
+            --acsengine-hyperkube-url=k8s-gcrio.azureedge.net/hyperkube-amd64:v1.11.0 \
+            --acsengine-win-binaries-url=https://acs-mirror.azureedge.net/wink8s/v1.11.0-1int.zip \
             --acsengine-creds=$AZURE_CREDENTIALS --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE \
             --acsengine-winZipBuildScript=$WIN_BUILD --acsengine-location=${LOCATION} \
             --acsengine-networkPlugin=${NETWORK_PLUGIN} \


### PR DESCRIPTION
Reverts e2e-win/e2e-win-prow-deployment#24

Testing with kubenet revealed no cni errors on 1.10. Going back to 1.11